### PR TITLE
[feature] add argus_service_enable

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -8,6 +8,7 @@ argus_conf_dir: "{{ __argus_conf_dir }}"
 argus_conf_file: "{{ __argus_conf_dir }}/argus.conf"
 argus_pid_dir: "{{ __argus_pid_dir }}"
 argus_pid_file: "{{ __argus_pid_dir }}/{{ argus_service }}.pid"
+argus_service_enable: true
 
 argus_saslpassword_command: "{{ __argus_saslpassword_command }}"
 argus_sasldblistusers_command: "{{ __argus_sasldblistusers_command }}"

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -4,3 +4,5 @@
   service:
     name: argus
     state: restarted
+  when:
+    - argus_service_enable

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -29,5 +29,15 @@
 - name: Start argus
   service:
     name: "{{ argus_service }}"
-    enabled: true
+    enabled: yes
     state: started
+  when:
+    - argus_service_enable
+
+- name: Stop argus
+  service:
+    name: "{{ argus_service }}"
+    enabled: no
+    state: stopped
+  when:
+    - not argus_service_enable


### PR DESCRIPTION
when set to false value, the service is not eanbled nor started. useful
when you need common directories, user, and group, but do not need the
service itself.