### PR TITLE
[feature] make group and mode of logdir configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ None
 | `argus_user` | user of `argus` | `{{ __argus_user }}` |
 | `argus_group` | group of `argus` | `{{ __argus_group }}` |
 | `argus_log_dir` | path to log directory | `/var/log/argus` |
+| `argus_log_dir_mode` | permission of log directory | `0755` |
+| `argus_log_dir_group` | group of log directory | `{{ argus_group }}` |
 | `argus_service` | service name of `argus` | `{{ __argus_service }}` |
 | `argus_package` | package name of `argus` | `{{ __argus_package }}` |
 | `argus_conf_dir` | path to directory where `argus.conf` resides | `{{ __argus_conf_dir }}` |
@@ -130,6 +132,7 @@ argus_config:
         state: present
     cyrus_sasl_sasldb_group: argus
     cyrus_sasl_sasldb_file_permission: "0640"
+    argus_log_dir_mode: "0775"
     argus_config:
       ARGUS_CHROOT: "{{ argus_log_dir }}"
       ARGUS_FLOW_TYPE: Bidirectional

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,8 @@
 argus_user: "{{ __argus_user }}"
 argus_group: "{{ __argus_group }}"
 argus_log_dir: /var/log/argus
+argus_log_dir_group: "{{ argus_group }}"
+argus_log_dir_mode: "0755"
 argus_service: "{{ __argus_service }}"
 argus_package: "{{ __argus_package }}"
 argus_conf_dir: "{{ __argus_conf_dir }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -10,9 +10,9 @@
 - name: Create log directory
   file:
     path: "{{ argus_log_dir }}"
-    mode: 0755
+    mode: "{{ argus_log_dir_mode }}"
     owner: "{{ argus_user }}"
-    group: "{{ argus_group }}"
+    group: "{{ argus_log_dir_group }}"
     state: directory
   notify: Restart argus
 

--- a/tests/serverspec/default.yml
+++ b/tests/serverspec/default.yml
@@ -25,6 +25,7 @@
         state: present
     cyrus_sasl_sasldb_group: argus
     cyrus_sasl_sasldb_file_permission: "0640"
+    argus_log_dir_mode: "0775"
     argus_config:
       ARGUS_CHROOT: "{{ argus_log_dir }}"
       ARGUS_FLOW_TYPE: Bidirectional

--- a/tests/serverspec/default_spec.rb
+++ b/tests/serverspec/default_spec.rb
@@ -86,7 +86,7 @@ end
 
 describe file(log_dir) do
   it { should exist }
-  it { should be_mode 755 }
+  it { should be_mode 775 }
   it { should be_owned_by user }
   it { should be_grouped_into group }
 end


### PR DESCRIPTION
with this, `argus` and other users can share the log directory.
required by `ansible-role-argus-radium`